### PR TITLE
Fix lessons data pump to correctly send lesson_id instead of unit_id

### DIFF
--- a/coursebuilder/modules/analytics/rest_providers.py
+++ b/coursebuilder/modules/analytics/rest_providers.py
@@ -140,7 +140,7 @@ class LessonsDataSource(data_sources.AbstractSmallRestDataSource):
             'Lessons',
             description='Sets of lessons providing course content')
         reg.add_property(schema_fields.SchemaField(
-            'lesson_id', 'Unit ID', 'string',
+            'lesson_id', 'Lesson ID', 'string',
             description='Key uniquely identifying which lesson this is'))
         reg.add_property(schema_fields.SchemaField(
             'unit_id', 'Unit ID', 'string',
@@ -167,7 +167,7 @@ class LessonsDataSource(data_sources.AbstractSmallRestDataSource):
         ret = []
         for lesson in lessons:
             ret.append({
-                'lesson_id': str(lesson.unit_id),
+                'lesson_id': str(lesson.lesson_id),
                 'unit_id': str(lesson.unit_id),
                 'title': lesson.title,
                 'scored': lesson.scored,


### PR DESCRIPTION
When using the lessons data pump, GCB sends the unit_id where lesson_id should appear, making it impossible to match lesson rows with the corresponding data in student_aggregate. This commit replaces it with lesson_id.
